### PR TITLE
Support PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 sudo: false
 
 php:
+  - 5.5
   - 5.6
   - 7.0
   - hhvm

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ SHELL = /bin/sh
 .SILENT: help
 
 install: ## Download the depenedencies then build the image :rocket:.
+	docker pull php:5.5-cli
 	docker pull php:5.6-cli
 	docker pull php:7.0-cli
 	make 'composer-update --optimize-autoloader --ignore-platform-reqs'
@@ -21,6 +22,8 @@ test: ## Run the unit and intergration testsuites.
 test: test-unit test-benchmark
 
 test-unit: ## Run the unit testsuite.
+	docker run --rm -t -v $$(pwd):/opt/graze/formatter -w /opt/graze/formatter php:5.5-cli \
+	vendor/bin/phpunit --testsuite unit
 	docker run --rm -t -v $$(pwd):/opt/graze/formatter -w /opt/graze/formatter php:5.6-cli \
 	vendor/bin/phpunit --testsuite unit
 	docker run --rm -t -v $$(pwd):/opt/graze/formatter -w /opt/graze/formatter php:7.0-cli \

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,6 @@
     "require-dev": {
         "graze/hamcrest-test-listener": "^1.0",
         "hamcrest/hamcrest-php": "^1.2",
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8 || ^5.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,13 +30,13 @@
     },
 
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^5.5 || ^5.6 || ^7.0",
         "graze/sort": "^2.0.1"
     },
 
     "require-dev": {
         "graze/hamcrest-test-listener": "^1.0",
         "hamcrest/hamcrest-php": "^1.2",
-        "phpunit/phpunit": "^5.0"
+        "phpunit/phpunit": "^4.8"
     }
 }

--- a/src/AbstractFormatter.php
+++ b/src/AbstractFormatter.php
@@ -13,7 +13,6 @@
 
 namespace Graze\Formatter;
 
-use function Graze\Sort\schwartzian;
 use Graze\Formatter\Filter;
 use Graze\Formatter\FormatterInterface;
 use Graze\Formatter\Processor;
@@ -150,7 +149,7 @@ abstract class AbstractFormatter implements
     private function sort(array $unsorted)
     {
         if ($this->sorters) {
-            return schwartzian($unsorted, $this->sorters);
+            return \Graze\Sort\schwartzian($unsorted, $this->sorters);
         }
 
         return $unsorted;


### PR DESCRIPTION
This might be controversial.

My reasons are:
- We don't currently use this library internally (that I know of) and we should dogfood our own open source projects.
- I know we only supported 5.6 in the spirit of forcing the world to move forward, but we're not going to be upgrading to PHP 5.6 internally (likely to go straight to 7) and in the meantime I'd like to use this library in our internal applications.

Happy to talk more but don't want it to drag on, I either need to use this or I'm going to have to refactor the formatting code in our internal applications which I'd rather not do since we've got a library for it.
